### PR TITLE
configure Grafana Agent to run on port that doesn't need sudo on Linux

### DIFF
--- a/targets/grafana_agent.go
+++ b/targets/grafana_agent.go
@@ -15,6 +15,8 @@ func RunGrafanaAgent(opts TargetOptions) error {
 
 	// Write out config file.
 	cfg := fmt.Sprintf(`
+server:
+  http_listen_port: 8000
 prometheus:
   wal_directory: ./
   global:


### PR DESCRIPTION
Default is port 80, needed to run with sudo to get tests to pass. 