### PR TITLE
Order tests alphabetically

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,10 +18,10 @@ import (
 var (
 	logger  = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	runners = map[string]targets.Target{
-		"prometheus":    targets.RunPrometheus,
-		"otelcollector": targets.RunOtelCollector,
-		"telegraf":      targets.RunTelegraf,
 		"grafana":       targets.RunGrafanaAgent,
+		"otelcollector": targets.RunOtelCollector,
+		"prometheus":    targets.RunPrometheus,
+		"telegraf":      targets.RunTelegraf,
 		//"vmagent":       targets.RunVMAgent, // No download for Mac yet.
 	}
 	tests = []func() cases.Test{


### PR DESCRIPTION
An argument could be made that Prometheus should always come first.

Signed-off-by: Richard Hartmann <richih@richih.org>